### PR TITLE
fix: bearerFormat is OPTIONAL for bearer security schemes

### DIFF
--- a/security_scheme.go
+++ b/security_scheme.go
@@ -79,10 +79,8 @@ func (s *SecurityScheme) Validate() error {
 
 		if SecuritySchemeBearer == strings.ToLower(s.Scheme) {
 			s.Scheme = SecuritySchemeBearer // unify
-
-			if s.BearerFormat == "" {
-				return &errpath.ErrField{Field: "bearerFormat", Err: &errpath.ErrRequired{}}
-			}
+			// bearerFormat is OPTIONAL per spec — a hint to the client, primarily for documentation.
+			// See: https://spec.openapis.org/oas/v3.2.0.html#security-scheme-object
 		}
 	case SecuritySchemeTypeMutualTLS: // nothing to do
 	case SecuritySchemeTypeOAuth2:

--- a/security_scheme_test.go
+++ b/security_scheme_test.go
@@ -49,6 +49,9 @@ func TestSecurityScheme_Validate(t *testing.T) {
 
 	for _, tc := range []openapi.SecurityScheme{
 		{Type: openapi.SecuritySchemeTypeMutualTLS},
+		// bearerFormat is OPTIONAL — bearer without it must be valid.
+		// See: https://spec.openapis.org/oas/v3.2.0.html#security-scheme-object
+		{Type: openapi.SecuritySchemeTypeHTTP, Scheme: "bearer"},
 	} {
 		if err := tc.Validate(); err != nil {
 			t.Fatalf("%#v got error: %s", tc, err)
@@ -89,20 +92,6 @@ func TestSecurityScheme_Validate_Error(t *testing.T) {
 		{
 			openapi.SecurityScheme{Type: openapi.SecuritySchemeTypeHTTP},
 			`scheme is required`,
-		},
-		{
-			openapi.SecurityScheme{
-				Type:   openapi.SecuritySchemeTypeHTTP,
-				Scheme: "BeAReR",
-			},
-			`bearerFormat is required`,
-		},
-		{
-			openapi.SecurityScheme{
-				Type:   openapi.SecuritySchemeTypeHTTP,
-				Scheme: "BeAReR",
-			},
-			`bearerFormat is required`,
 		},
 		{
 			openapi.SecurityScheme{Type: openapi.SecuritySchemeTypeOAuth2},


### PR DESCRIPTION
## Summary

`SecurityScheme.Validate()` was requiring `bearerFormat` whenever `scheme: bearer`. The spec is explicit that it is optional:

> `bearerFormat` — **OPTIONAL**. A hint to the client to identify how the bearer token is formatted. Bearer tokens are usually generated by an authorization server, so this information is primarily for documentation purposes.

See: https://spec.openapis.org/oas/v3.2.0.html#security-scheme-object

## Test plan

- [ ] Removed the two duplicate `bearerFormat is required` error cases (they tested the now-removed constraint)
- [ ] Added `{Type: http, Scheme: bearer}` (no `bearerFormat`) as a valid case to `TestSecurityScheme_Validate`
- [ ] `go test ./...` passes

https://claude.ai/code/session_01QW6a1DAhDfmhqammM539iv