### PR TITLE
feat: accept OAS 3.2.x version strings

### DIFF
--- a/document.go
+++ b/document.go
@@ -45,8 +45,9 @@ type Document struct {
 }
 
 // reOpenAPIVersion is a regular expression that matches the OpenAPI version.
-// Allowed are 3.0.x and 3.1.x.
-var reOpenAPIVersion = regexp.MustCompile(`^3\.(0|1)\.\d+(-.+)?$`)
+// Allowed are 3.0.x, 3.1.x and 3.2.x.
+// See: https://spec.openapis.org/oas/v3.2.0.html#versions-and-deprecation
+var reOpenAPIVersion = regexp.MustCompile(`^3\.(0|1|2)\.\d+(-.+)?$`)
 
 // Validate checks the OpenAPI document for correctness.
 func (d *Document) Validate() error {
@@ -59,7 +60,7 @@ func (d *Document) Validate() error {
 			Field: "openapi",
 			Err: &errpath.ErrInvalid[string]{
 				Value:   d.OpenAPI,
-				Message: "must be a valid version (3.0.x or 3.1.x)",
+				Message: "must be a valid version (3.0.x, 3.1.x or 3.2.x)",
 			},
 		}
 	}

--- a/document_test.go
+++ b/document_test.go
@@ -27,6 +27,16 @@ func TestDocument_JSON(t *testing.T) {
 func TestDocument_Validate(t *testing.T) {
 	t.Parallel()
 
+	// OAS 3.2.x documents must be accepted.
+	// See: https://spec.openapis.org/oas/v3.2.0.html#versions-and-deprecation
+	if err := (&openapi.Document{
+		OpenAPI: "3.2.0",
+		Info:    &openapi.Info{Title: "Test", Version: "1.0"},
+		Paths:   openapi.Paths{"/": {}},
+	}).Validate(); err != nil {
+		t.Fatal(err)
+	}
+
 	doc := &openapi.Document{
 		OpenAPI: "3.1.0",
 		Info: &openapi.Info{
@@ -98,7 +108,7 @@ func TestDocumentValidate_Error(t *testing.T) {
 		{&openapi.Document{}, "openapi is required"},
 		{&openapi.Document{
 			OpenAPI: "foo",
-		}, `openapi ("foo") is invalid: must be a valid version (3.0.x or 3.1.x)`},
+		}, `openapi ("foo") is invalid: must be a valid version (3.0.x, 3.1.x or 3.2.x)`},
 		{&openapi.Document{
 			OpenAPI: "3.1.0",
 		}, `info is required`},


### PR DESCRIPTION
## Summary

The version regex `^3\.(0|1)\.\d+` rejected any `3.2.x` document outright. Extended the alternation to `(0|1|2)` and updated the error message accordingly.

See: https://spec.openapis.org/oas/v3.2.0.html#versions-and-deprecation

## Test plan

- [ ] Added a `3.2.0` document success case to `TestDocument_Validate`
- [ ] Updated the error message in `TestDocumentValidate_Error` to `3.0.x, 3.1.x or 3.2.x`
- [ ] `go test ./...` passes

https://claude.ai/code/session_01QW6a1DAhDfmhqammM539iv