### PR TITLE
fix: accept unknown formats as annotations instead of erroring

### DIFF
--- a/data_type_format.go
+++ b/data_type_format.go
@@ -1,12 +1,11 @@
 package openapi
 
-import (
-	"slices"
-
-	"github.com/MarkRosemaker/errpath"
-)
-
 // Format defines additional formats to provide fine detail for primitive data types.
+// The format property is an open string-valued property and can have any value.
+// Formats such as "email", "uuid", and so on, MAY be used even though they are not
+// defined by this specification. Tools that do not recognize a specific format MUST
+// treat it like a plain schema object and MUST NOT generate an error.
+// See: https://spec.openapis.org/oas/v3.2.0.html#data-types
 type Format string
 
 const (
@@ -51,27 +50,3 @@ const (
 	// FormatIPv6 represents an IPv6 address.
 	FormatIPv6 Format = "ipv6"
 )
-
-var allFormats = []Format{
-	FormatInt32, FormatInt64,
-	FormatUint, FormatUint32, FormatUint64,
-	FormatFloat, FormatDouble,
-	FormatByte, FormatBinary,
-	FormatDate, FormatDateTime, FormatDuration,
-	FormatEmail, FormatPassword,
-	FormatUUID,
-	FormatURI, FormatURIRef, FormatZipCode,
-	FormatIPv4, FormatIPv6,
-}
-
-// Validate validates the format.
-func (f Format) Validate() error {
-	if slices.Contains(allFormats, f) {
-		return nil
-	}
-
-	return &errpath.ErrInvalid[Format]{
-		Value: f,
-		Enum:  allFormats,
-	}
-}

--- a/data_type_format_test.go
+++ b/data_type_format_test.go
@@ -3,26 +3,22 @@ package openapi_test
 import (
 	"testing"
 
-	"github.com/MarkRosemaker/errpath"
 	"github.com/MarkRosemaker/openapi"
 )
 
-const validFormats = `"int32", "int64", "uint", "uint32", "uint64", "float", "double", "byte", "binary", "date", "date-time", "duration", "email", "password", "uuid", "uri", "uriref", "zip-code", "ipv4", "ipv6"`
+func TestSchema_UnknownFormat(t *testing.T) {
+	t.Parallel()
 
-func TestFormat(t *testing.T) {
-	// test a valid data type format
-	if err := openapi.FormatDateTime.Validate(); err != nil {
-		t.Fatal(err)
-	}
-
-	// test an invalid data type format
-	err := openapi.Format("foo").Validate()
-	if err == nil {
-		t.Fatal("expected an error for an invalid data type")
-	}
-
-	err = &errpath.ErrField{Field: "format", Err: err}
-	if want := `format ("foo") is invalid, must be one of: ` + validFormats; want != err.Error() {
-		t.Fatalf("want: %s, got: %s", want, err)
+	// Unknown formats are accepted as annotations per spec — tools MUST NOT generate an error.
+	// See: https://spec.openapis.org/oas/v3.2.0.html#data-types
+	for _, f := range []openapi.Format{
+		"hostname", "idn-email", "idn-hostname", "iri", "iri-reference",
+		"json-pointer", "relative-json-pointer", "regex", "uri-template",
+		openapi.Format("my-custom-format"),
+	} {
+		s := &openapi.Schema{Type: openapi.TypeString, Format: f}
+		if err := s.Validate(); err != nil {
+			t.Fatalf("format %q should be accepted: %s", f, err)
+		}
 	}
 }

--- a/schema.go
+++ b/schema.go
@@ -103,13 +103,8 @@ func (s *Schema) Validate() error {
 		return &errpath.ErrField{Field: "type", Err: err}
 	}
 
-	if s.Format != "" {
-		if err := s.Format.Validate(); err != nil {
-			return &errpath.ErrField{Field: "format", Err: err}
-		}
-	}
-
-	// validate if format is valid for type
+	// validate if format is compatible with type (known formats only; unknown formats are accepted)
+	// See: https://spec.openapis.org/oas/v3.2.0.html#data-types
 	switch s.Format {
 	case "": // no format
 	case FormatInt32, FormatInt64, FormatUint, FormatUint32, FormatUint64:
@@ -154,7 +149,7 @@ func (s *Schema) Validate() error {
 			}}
 		}
 	default:
-		return fmt.Errorf("unimplemented format: %s", s.Format)
+		// unknown format — accepted as an annotation, not validated
 	}
 
 	for i, v := range s.AllOf {

--- a/schema_test.go
+++ b/schema_test.go
@@ -51,10 +51,6 @@ func TestSchema_Validate_Error(t *testing.T) {
 		}, `items is required`},
 		{openapi.Schema{
 			Type:   openapi.TypeString,
-			Format: "foo",
-		}, `format ("foo") is invalid, must be one of: ` + validFormats},
-		{openapi.Schema{
-			Type:   openapi.TypeString,
 			Format: openapi.FormatInt64,
 		}, `format ("int64") is invalid: only valid for integer type, got string`},
 		{openapi.Schema{


### PR DESCRIPTION
## Summary

The spec is explicit that format is an open string-valued property. Tools MUST NOT generate an error for unknown formats — they should treat the schema as if format were absent.
See: https://spec.openapis.org/oas/v3.2.0.html#data-types

- Removes \`Format.Validate()\` and the \`allFormats\` allowlist
- Removes the \`"unimplemented format"\` error from the type-compatibility switch
- Known formats (\`int32\`, \`uuid\`, \`date-time\`, etc.) still validate type-compatibility (e.g. \`int32\` requires \`integer\` type)

## Test plan

- [ ] \`TestSchema_UnknownFormat\` — common real-world formats (\`hostname\`, \`idn-email\`, \`uri-template\`, \`regex\`, custom) all pass validation
- [ ] Removed the \`format ("foo") is invalid\` error case from \`TestSchemaValidate_Error\`
- [ ] \`go test ./...\` passes

https://claude.ai/code/session_01QW6a1DAhDfmhqammM539iv