### PR TITLE
feat: add TypeNull ("null") as a valid schema data type

### DIFF
--- a/data_type.go
+++ b/data_type.go
@@ -12,7 +12,7 @@ import (
 //
 // ([Specification])
 //
-// [Specification]: https://spec.openapis.org/oas/v3.1.0#data-types
+// [Specification]: https://spec.openapis.org/oas/v3.2.0.html#data-types
 type DataType string
 
 const (
@@ -22,10 +22,13 @@ const (
 	TypeArray   DataType = "array"
 	TypeBoolean DataType = "boolean"
 	TypeObject  DataType = "object"
+	// TypeNull represents a null value.
+	// See: https://spec.openapis.org/oas/v3.2.0.html#data-types
+	TypeNull DataType = "null"
 )
 
 var allDataTypes = []DataType{
-	TypeInteger, TypeNumber, TypeString, TypeArray, TypeBoolean, TypeObject,
+	TypeInteger, TypeNumber, TypeString, TypeArray, TypeBoolean, TypeObject, TypeNull,
 }
 
 func (d DataType) Validate() error {

--- a/data_type_test.go
+++ b/data_type_test.go
@@ -13,6 +13,12 @@ func TestDataType(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// null is a valid type in JSON Schema 2020-12 / OAS 3.2.0
+	// See: https://spec.openapis.org/oas/v3.2.0.html#data-types
+	if err := openapi.TypeNull.Validate(); err != nil {
+		t.Fatal(err)
+	}
+
 	// test an invalid data type
 	err := openapi.DataType("foo").Validate()
 	if err == nil {
@@ -20,7 +26,7 @@ func TestDataType(t *testing.T) {
 	}
 
 	err = &errpath.ErrField{Field: "type", Err: err}
-	if want := `type ("foo") is invalid, must be one of: "integer", "number", "string", "array", "boolean", "object"`; want != err.Error() {
+	if want := `type ("foo") is invalid, must be one of: "integer", "number", "string", "array", "boolean", "object", "null"`; want != err.Error() {
 		t.Fatalf("expected %q, got %q", want, err.Error())
 	}
 }

--- a/schema_test.go
+++ b/schema_test.go
@@ -45,7 +45,7 @@ func TestSchema_Validate_Error(t *testing.T) {
 		{openapi.Schema{}, "type is required"},
 		{openapi.Schema{
 			Type: "foo",
-		}, `type ("foo") is invalid, must be one of: "integer", "number", "string", "array", "boolean", "object"`},
+		}, `type ("foo") is invalid, must be one of: "integer", "number", "string", "array", "boolean", "object", "null"`},
 		{openapi.Schema{
 			Type: openapi.TypeArray,
 		}, `items is required`},


### PR DESCRIPTION
## Summary

JSON Schema Draft 2020-12 and OAS 3.2.0 recognise \`"null"\` as a valid type value. It was missing from the \`DataType\` constants and the \`allDataTypes\` validation allowlist, causing any schema with \`type: null\` to be rejected with an invalid-type error.
See: https://spec.openapis.org/oas/v3.2.0.html#data-types

## Test plan

- [x] \`TypeNull.Validate()\` passes (new case in \`TestDataType\`)
- [x] Invalid-type error message updated to include \`"null"\` in both \`TestDataType\` and \`TestSchemaValidate_Error\`
- [x] \`go test ./...\` passes

https://claude.ai/code/session_01QW6a1DAhDfmhqammM539iv